### PR TITLE
Refactor processor package and make BatchProcessor implementations override named parameters correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
 .DS_Store
-/build
+**/build/
 /captures
 .externalNativeBuild
 .cxx

--- a/core/src/main/java/com/fpf/smartscansdk/core/processors/BatchProcessor.kt
+++ b/core/src/main/java/com/fpf/smartscansdk/core/processors/BatchProcessor.kt
@@ -3,7 +3,6 @@ package com.fpf.smartscansdk.core.processors
 import android.app.Application
 import android.content.Context
 import android.util.Log
-import com.fpf.smartscansdk.core.utils.MemoryUtils
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async

--- a/core/src/main/java/com/fpf/smartscansdk/core/processors/IProcessorListener.kt
+++ b/core/src/main/java/com/fpf/smartscansdk/core/processors/IProcessorListener.kt
@@ -1,0 +1,12 @@
+package com.fpf.smartscansdk.core.processors
+
+import android.content.Context
+
+interface IProcessorListener<Input, Output> {
+    suspend fun onActive(context: Context) = Unit
+    suspend fun onBatchComplete(context: Context, batch: List<Output>) = Unit
+    suspend fun onComplete(context: Context, metrics: Metrics.Success) = Unit
+    suspend fun onProgress(context: Context, progress: Float) = Unit
+    fun onError(context: Context, error: Exception, item: Input) = Unit
+    suspend fun onFail(context: Context, failureMetrics: Metrics.Failure) = Unit
+}

--- a/core/src/main/java/com/fpf/smartscansdk/core/processors/MemoryUtils.kt
+++ b/core/src/main/java/com/fpf/smartscansdk/core/processors/MemoryUtils.kt
@@ -34,10 +34,3 @@ class MemoryUtils(
         }
     }
 }
-
-data class MemoryOptions(
-    val lowMemoryThreshold: Long = 800L * 1024 * 1024,
-    val highMemoryThreshold: Long = 1_600L * 1024 * 1024,
-    val minConcurrency: Int = 1,
-    val maxConcurrency: Int = 4
-)

--- a/core/src/main/java/com/fpf/smartscansdk/core/processors/MemoryUtils.kt
+++ b/core/src/main/java/com/fpf/smartscansdk/core/processors/MemoryUtils.kt
@@ -1,4 +1,4 @@
-package com.fpf.smartscansdk.core.utils
+package com.fpf.smartscansdk.core.processors
 
 import android.app.ActivityManager
 import android.content.Context

--- a/core/src/main/java/com/fpf/smartscansdk/core/processors/ProcessorData.kt
+++ b/core/src/main/java/com/fpf/smartscansdk/core/processors/ProcessorData.kt
@@ -1,7 +1,5 @@
 package com.fpf.smartscansdk.core.processors
 
-import android.content.Context
-
 sealed class Metrics {
     data class Success(val totalProcessed: Int = 0, val timeElapsed: Long = 0L) : Metrics()
     data class Failure(val processedBeforeFailure: Int, val timeElapsed: Long, val error: Exception) : Metrics()

--- a/core/src/main/java/com/fpf/smartscansdk/core/processors/ProcessorData.kt
+++ b/core/src/main/java/com/fpf/smartscansdk/core/processors/ProcessorData.kt
@@ -5,6 +5,12 @@ sealed class Metrics {
     data class Failure(val processedBeforeFailure: Int, val timeElapsed: Long, val error: Exception) : Metrics()
 }
 
+data class MemoryOptions(
+    val lowMemoryThreshold: Long = 800L * 1024 * 1024,
+    val highMemoryThreshold: Long = 1_600L * 1024 * 1024,
+    val minConcurrency: Int = 1,
+    val maxConcurrency: Int = 4
+)
 
 data class ProcessOptions(
     val memory: MemoryOptions = MemoryOptions(),

--- a/core/src/main/java/com/fpf/smartscansdk/core/processors/ProcessorTypes.kt
+++ b/core/src/main/java/com/fpf/smartscansdk/core/processors/ProcessorTypes.kt
@@ -1,9 +1,6 @@
 package com.fpf.smartscansdk.core.processors
 
 import android.content.Context
-import com.fpf.smartscansdk.core.utils.MemoryOptions
-
-enum class ProcessorStatus {IDLE, ACTIVE, COMPLETE, FAILED }
 
 sealed class Metrics {
     data class Success(val totalProcessed: Int = 0, val timeElapsed: Long = 0L) : Metrics()
@@ -16,11 +13,3 @@ data class ProcessOptions(
     val batchSize: Int = 10
 )
 
-interface IProcessorListener<Input, Output> {
-    suspend fun onActive(context: Context) = Unit
-    suspend fun onBatchComplete(context: Context, batch: List<Output>) = Unit
-    suspend fun onComplete(context: Context, metrics: Metrics.Success) = Unit
-    suspend fun onProgress(context: Context, progress: Float) = Unit
-    fun onError(context: Context, error: Exception, item: Input) = Unit
-    suspend fun onFail(context: Context, failureMetrics: Metrics.Failure) = Unit
-}

--- a/core/src/test/kotlin/com/fpf/smartscansdk/core/processors/BatchProcessorTest.kt
+++ b/core/src/test/kotlin/com/fpf/smartscansdk/core/processors/BatchProcessorTest.kt
@@ -2,7 +2,6 @@ package com.fpf.smartscansdk.core.processors
 
 import android.app.Application
 import android.util.Log
-import com.fpf.smartscansdk.core.utils.MemoryUtils
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach

--- a/extensions/src/main/java/com/fpf/smartscansdk/extensions/indexers/ImageIndexer.kt
+++ b/extensions/src/main/java/com/fpf/smartscansdk/extensions/indexers/ImageIndexer.kt
@@ -36,16 +36,16 @@ class ImageIndexer(
         store.add(batch)
     }
 
-    override suspend fun onProcess(context: Context, id: Long): Embedding {
+    override suspend fun onProcess(context: Context, item: Long): Embedding {
         val contentUri = ContentUris.withAppendedId(
-            MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI, item
         )
         val bitmap = getBitmapFromUri(context, contentUri, ClipConfig.IMAGE_SIZE_X)
         val embedding = withContext(NonCancellable) {
             embedder.embed(bitmap)
         }
         return Embedding(
-            id = id,
+            id = item,
             date = System.currentTimeMillis(),
             embeddings = embedding
         )

--- a/extensions/src/main/java/com/fpf/smartscansdk/extensions/indexers/VideoIndexer.kt
+++ b/extensions/src/main/java/com/fpf/smartscansdk/extensions/indexers/VideoIndexer.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.provider.MediaStore
 import com.fpf.smartscansdk.core.ml.embeddings.Embedding
 import com.fpf.smartscansdk.core.ml.embeddings.IEmbeddingStore
-import com.fpf.smartscansdk.core.ml.embeddings.clip.ClipConfig.CLIP_EMBEDDING_LENGTH
 import com.fpf.smartscansdk.core.ml.embeddings.clip.ClipConfig.IMAGE_SIZE_X
 import com.fpf.smartscansdk.core.ml.embeddings.clip.ClipConfig.IMAGE_SIZE_Y
 import com.fpf.smartscansdk.core.ml.embeddings.clip.ClipImageEmbedder
@@ -15,7 +14,6 @@ import com.fpf.smartscansdk.core.processors.BatchProcessor
 import com.fpf.smartscansdk.core.processors.IProcessorListener
 import com.fpf.smartscansdk.core.processors.ProcessOptions
 import com.fpf.smartscansdk.core.utils.extractFramesFromVideo
-import com.fpf.smartscansdk.extensions.embeddings.FileEmbeddingStore
 
 // ** Design Constraint**: For on-device vector search, the full index needs to be loaded in-memory (or make an Android native VectorDB)
 // File-based EmbeddingStore is used over a Room version due to significant faster index loading
@@ -42,9 +40,9 @@ class VideoIndexer(
         store.add(batch)
     }
 
-    override suspend fun onProcess(context: Context, id: Long): Embedding {
+    override suspend fun onProcess(context: Context, item: Long): Embedding {
         val contentUri = ContentUris.withAppendedId(
-            MediaStore.Video.Media.EXTERNAL_CONTENT_URI, id
+            MediaStore.Video.Media.EXTERNAL_CONTENT_URI, item
         )
         val frameBitmaps = extractFramesFromVideo(context, contentUri, width = width, height = height, frameCount = frameCount)
 
@@ -54,7 +52,7 @@ class VideoIndexer(
         val embedding: FloatArray = generatePrototypeEmbedding(rawEmbeddings)
 
         return Embedding(
-            id = id,
+            id = item,
             date = System.currentTimeMillis(),
             embeddings = embedding
         )


### PR DESCRIPTION
* Moved MemoryUtils into processor
* Moved IProcessorListener to its own file
* Moved MemoryOptions into ProcessorData.kt
* Update indexers to users correctly named parameter item instead of id to prevent issues with named parameters